### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r server/requirements.txt
+      - name: Check Python syntax
+        run: |
+          python -m py_compile server/wikicit_server.py

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,7 @@ This project demonstrates a Chrome extension that replaces "citation needed" pla
 ## Using the extension
 
 Load the `chromeext/` directory as an unpacked extension in Chrome and navigate to a Wikipedia page containing "citation needed" markers. The extension will query the server for a citation and insert it into the page.
+
+## Continuous Integration
+
+A simple GitHub Actions workflow is included in `.github/workflows/ci.yml`. It installs the server dependencies and checks that `wikicit_server.py` compiles without errors. Push this repository to GitHub and open the **Actions** tab to see the workflow run. The URL of a run follows the pattern `https://github.com/<user>/<repo>/actions/runs/<run-id>`.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to check Python syntax
- document how to view workflow runs

## Testing
- `python -m py_compile server/wikicit_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684a7b12ba288327be104c0ddda4cc05