### PR TITLE
Add streaming server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r server/requirements.txt
+      - name: Check Python syntax
+        run: |
+          python -m py_compile server/wikicit_server.py server/stream_server.py

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,18 @@ This project demonstrates a Chrome extension that replaces "citation needed" pla
 ## Using the extension
 
 Load the `chromeext/` directory as an unpacked extension in Chrome and navigate to a Wikipedia page containing "citation needed" markers. The extension will query the server for a citation and insert it into the page.
+
+## Continuous Integration
+
+A simple GitHub Actions workflow is included in `.github/workflows/ci.yml`. It installs the server dependencies and checks that `wikicit_server.py` compiles without errors. Push this repository to GitHub and open the **Actions** tab to see the workflow run. The URL of a run follows the pattern `https://github.com/<user>/<repo>/actions/runs/<run-id>`.
+
+## Live streaming server
+
+To share a webcam stream with a friend, install the additional dependency and run the streaming server:
+
+```bash
+pip install opencv-python
+python server/stream_server.py
+```
+
+The server listens on port 5000. Visit `http://<your-ip>:5000` from your phone's browser to see the stream and share that link with anyone on the same network.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 openai
+
+opencv-python

--- a/server/stream_server.py
+++ b/server/stream_server.py
@@ -1,0 +1,31 @@
+import os
+import cv2
+from flask import Flask, Response, render_template_string
+
+app = Flask(__name__)
+
+camera = cv2.VideoCapture(0)
+
+def gen_frames():
+    while True:
+        success, frame = camera.read()
+        if not success:
+            break
+        ret, buffer = cv2.imencode('.jpg', frame)
+        frame = buffer.tobytes()
+        yield (b'--frame\r\n'
+               b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+
+@app.route('/')
+def index():
+    html = '<html><body><h1>Live Stream</h1><img src="/video"></body></html>'
+    return render_template_string(html)
+
+@app.route('/video')
+def video():
+    return Response(gen_frames(),
+                    mimetype='multipart/x-mixed-replace; boundary=frame')
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- add a new Flask script `stream_server.py` that streams webcam video
- update CI workflow to compile the new script
- document how to run the streaming server
- include `opencv-python` in server requirements

## Testing
- `python -m py_compile server/wikicit_server.py server/stream_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684a7b12ba288327be104c0ddda4cc05